### PR TITLE
ci: add changeset verification to PR checks

### DIFF
--- a/.changeset/ci-changeset-check.md
+++ b/.changeset/ci-changeset-check.md
@@ -1,0 +1,5 @@
+---
+"pkglab": patch
+---
+
+Add changeset verification to CI workflow

--- a/.changeset/ci-changeset-check.md
+++ b/.changeset/ci-changeset-check.md
@@ -1,5 +1,5 @@
 ---
-"pkglab": patch
+'pkglab': patch
 ---
 
 Add changeset verification to CI workflow

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,16 +38,16 @@ jobs:
     runs-on: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - run: bun install
-
-      - run: bunx changeset status --since=origin/main
+      - name: Check for changeset
+        run: |
+          changesets=$(find .changeset -name '*.md' ! -name 'README.md' 2>/dev/null)
+          if [ -z "$changesets" ]; then
+            echo "::error::No changeset found. Run 'bunx changeset' to add one."
+            exit 1
+          fi
+          echo "Found changesets:"
+          echo "$changesets"
 
   test:
     name: Test (${{ matrix.os }})

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,22 @@ jobs:
 
       - run: bun run format:check
 
+  changeset:
+    name: Changeset
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - run: bun install
+
+      - run: bunx changeset status --since=origin/main
+
   test:
     name: Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Summary
- Adds a `Changeset` job to the CI workflow that runs `changeset status --since=origin/main`
- PRs without a changeset will fail this check

## Test plan
- [ ] Open a PR without a changeset and verify the check fails
- [ ] Open a PR with a changeset and verify the check passes