### PR TITLE
chore: add changeset for #17

### DIFF
--- a/.changeset/retry-upstream-packuments.md
+++ b/.changeset/retry-upstream-packuments.md
@@ -1,0 +1,5 @@
+---
+"pkglab": patch
+---
+
+Buffer and validate upstream packument responses before serving to npm clients, with retry on corrupted JSON. Fixes transient CI failures with large packuments.


### PR DESCRIPTION
Adds the missing changeset for #17 (upstream packument retry and validation fix).

Patch bump for `pkglab`.