### PR TITLE
refactor: extract catalog.ts and install-orchestrator.ts

### DIFF
--- a/.changeset/refactor-composable-modules.md
+++ b/.changeset/refactor-composable-modules.md
@@ -1,0 +1,5 @@
+---
+"pkglab": patch
+---
+
+refactor: extract catalog.ts and install-orchestrator.ts from consumer.ts and pub.ts

--- a/.changeset/refactor-composable-modules.md
+++ b/.changeset/refactor-composable-modules.md
@@ -1,5 +1,5 @@
 ---
-"pkglab": patch
+'pkglab': patch
 ---
 
 refactor: extract catalog.ts and install-orchestrator.ts from consumer.ts and pub.ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,6 @@
 - 02f69d6: Cross-platform PID validation with Linux /proc fallback, exclusive lock for listener startup, user-specific log directory
 - f5303e3: Harden daemon startup race, stop verification, stderr drain, and PID validation
 - aa3cade: Fix correctness, crash safety, and race condition bugs across commands and core libraries
-
   - Fix re-add overwriting original version in repo state (add.ts)
   - Scan peerDependencies and optionalDependencies during version updates (consumer.ts)
   - Fix npmrc marker removal when markers are out of order (consumer.ts)

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -5,6 +5,7 @@ import type { VersionEntry, CatalogFormat } from '../lib/consumer';
 import type { pkglabConfig, RepoState } from '../types';
 
 import { getPositionalArgs, normalizeScope } from '../lib/args';
+import { findCatalogRoot, findCatalogEntry, loadCatalogData } from '../lib/catalog';
 import { c } from '../lib/color';
 import { loadConfig } from '../lib/config';
 import {
@@ -12,9 +13,6 @@ import {
   injectPreCommitHook,
   ensureNpmrcForActiveRepos,
   installWithVersionUpdates,
-  findCatalogRoot,
-  findCatalogEntry,
-  loadCatalogData,
 } from '../lib/consumer';
 import { ensureDaemonRunning } from '../lib/daemon';
 import { CommandError, SilentExitError } from '../lib/errors';

--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -1,8 +1,8 @@
 import { defineCommand } from 'citty';
 import { join, resolve, relative } from 'node:path';
 
-import type { VersionEntry, CatalogFormat } from '../lib/consumer';
-import type { pkglabConfig, RepoState } from '../types';
+import type { CatalogFormat } from '../lib/catalog';
+import type { pkglabConfig, RepoState, VersionEntry } from '../types';
 
 import { getPositionalArgs, normalizeScope } from '../lib/args';
 import { findCatalogRoot, findCatalogEntry, loadCatalogData } from '../lib/catalog';

--- a/src/commands/pub.ts
+++ b/src/commands/pub.ts
@@ -1,25 +1,20 @@
 import { defineCommand } from 'citty';
 
-import type { RepoWorkItem, LockfilePatchEntry } from '../lib/consumer';
 import type { SpinnerLine } from '../lib/spinner';
 import type { WorkspacePackage, PublishEntry, RepoEntry } from '../types';
 
 import { getPositionalArgs } from '../lib/args';
 import { type ChangeReason, type CascadeResult, runCascade } from '../lib/cascade';
+import { loadCatalogs } from '../lib/catalog';
 import { c } from '../lib/color';
 import { loadConfig } from '../lib/config';
-import {
-  buildConsumerWorkItems,
-  buildVersionEntries,
-  installWithVersionUpdates,
-  recoverPendingUpdate,
-} from '../lib/consumer';
+import { recoverPendingUpdate } from '../lib/consumer';
 import { ensureDaemonRunning } from '../lib/daemon';
 import { CommandError, pkglabError } from '../lib/errors';
 import { type PackageFingerprint } from '../lib/fingerprint';
 import { saveFingerprintState } from '../lib/fingerprint-state';
 import { buildDependencyGraph, precomputeTransitiveDeps } from '../lib/graph';
-import { runPreHook, runPostHook, runErrorHook } from '../lib/hooks';
+import { type RepoWorkItem, buildConsumerWorkItems, runRepoInstall } from '../lib/install-orchestrator';
 import { acquirePublishLock } from '../lib/lock';
 import { fetchIntegrityHashes } from '../lib/lockfile-patch';
 import { log } from '../lib/log';
@@ -31,7 +26,7 @@ import { saveRepoByPath } from '../lib/repo-state';
 import { createMultiSpinner } from '../lib/spinner';
 import { prefetchUpdateCheck } from '../lib/update-check';
 import { generateVersion, sanitizeTag } from '../lib/version';
-import { discoverWorkspace, findPackage, loadCatalogs } from '../lib/workspace';
+import { discoverWorkspace, findPackage } from '../lib/workspace';
 
 async function resolveTag(args: Record<string, unknown>): Promise<string | undefined> {
   if (args.tag && args.worktree) {
@@ -658,132 +653,4 @@ async function publishPackages(
     }
     await releaseLock();
   }
-}
-
-async function runRepoInstall(
-  repo: RepoWorkItem,
-  hookOpts?: { tag: string | undefined; port: number; verbose: boolean },
-  getIntegrityMap?: () => Promise<Map<string, string>>,
-  noPmOptimizations = false,
-  onLockfilePatched?: (entryCount: number) => void,
-): Promise<'ok' | 'skipped'> {
-  const { entries, catalogRoot } = await buildVersionEntries(repo);
-
-  // Build hook context if hook opts provided
-  const hookCtx = hookOpts
-    ? {
-        event: 'update' as const,
-        packages: repo.packages.map(e => ({
-          name: e.name,
-          version: e.version,
-          previous: repo.state.packages[e.name]?.current,
-        })),
-        tag: hookOpts.tag ?? null,
-        repoPath: repo.state.path,
-        registryUrl: `http://127.0.0.1:${hookOpts.port}`,
-        packageManager: repo.pm,
-      }
-    : null;
-
-  // Pre-update hook
-  if (hookCtx) {
-    const preResult = await runPreHook(hookCtx);
-    if (preResult.status === 'ok') {
-      log.success(`  pre-update (${(preResult.durationMs / 1000).toFixed(1)}s)`);
-    } else if (preResult.status === 'aborted' || preResult.status === 'failed' || preResult.status === 'timed_out') {
-      const label = preResult.status === 'timed_out' ? 'timed out' : `aborted (exit ${preResult.exitCode ?? 1})`;
-      log.warn(`  pre-update ${label} - skipped`);
-      await runErrorHook({
-        ...hookCtx,
-        error: { stage: 'pre-hook', message: `pre-update hook ${label}`, failedHook: 'pre-update' },
-      });
-      return 'skipped';
-    }
-  }
-
-  // Build lockfile patch entries for pnpm repos.
-  // Include ALL published packages (not just tracked ones) because the lockfile
-  // may contain transitive pkglab dependencies that also need integrity updates.
-  let patchEntries: LockfilePatchEntry[] | undefined;
-  if (repo.pm === 'pnpm' && getIntegrityMap) {
-    const integrityMap = await getIntegrityMap();
-    if (integrityMap.size > 0) {
-      // Pre-compute fallback for transitive deps not directly tracked
-      const fallbackOldVersion = Object.values(repo.state.packages).find(p => p.current)?.current;
-      patchEntries = [];
-      for (const [name, integrity] of integrityMap) {
-        const oldVersion = repo.state.packages[name]?.current ?? fallbackOldVersion;
-        const newVersion = repo.packages.find(p => p.name === name)?.version ?? repo.packages[0].version;
-        if (oldVersion) {
-          patchEntries.push({ name, oldVersion, newVersion, integrity });
-        }
-      }
-    }
-  }
-
-  // Install and save state.
-  // Save pending state before install so crash recovery can detect dirty consumers.
-  try {
-    // Mark pending update before modifying consumer files.
-    // Capture current versions so crash recovery can roll back.
-    repo.state.pendingUpdate = {
-      packages: Object.fromEntries(
-        entries.map(e => {
-          const link = repo.state.packages[e.name];
-          return [
-            e.name,
-            e.targets.map(t => {
-              const existingTarget = link?.targets.find(lt => lt.dir === t.dir);
-              return { dir: t.dir, original: existingTarget?.original ?? link?.current ?? '' };
-            }),
-          ];
-        }),
-      ),
-      timestamp: Date.now(),
-    };
-    await saveRepoByPath(repo.state.path, repo.state);
-
-    await installWithVersionUpdates({
-      repoPath: repo.state.path,
-      catalogRoot,
-      entries,
-      pm: repo.pm,
-      registryUrl: hookOpts ? `http://127.0.0.1:${hookOpts.port}` : undefined,
-      patchEntries,
-      noPmOptimizations,
-      onLockfilePatched,
-    });
-
-    for (const entry of repo.packages) {
-      const link = repo.state.packages[entry.name];
-      if (link) {
-        link.current = entry.version;
-      }
-    }
-    // Clear pending state on success
-    delete repo.state.pendingUpdate;
-    await saveRepoByPath(repo.state.path, repo.state);
-  } catch (err) {
-    if (hookCtx) {
-      const message = err instanceof Error ? err.message : String(err);
-      await runErrorHook({
-        ...hookCtx,
-        error: { stage: 'operation', message, failedHook: null },
-      });
-    }
-    throw err;
-  }
-
-  // Post-update hook
-  if (hookCtx) {
-    const postResult = await runPostHook(hookCtx);
-    if (postResult.status === 'ok') {
-      log.success(`  post-update (${(postResult.durationMs / 1000).toFixed(1)}s)`);
-    } else if (postResult.status === 'failed' || postResult.status === 'timed_out') {
-      const label = postResult.status === 'timed_out' ? 'timed out' : `failed (exit ${postResult.exitCode ?? 1})`;
-      log.warn(`  post-update hook ${label}`);
-    }
-  }
-
-  return 'ok';
 }

--- a/src/lib/__tests__/catalog.test.ts
+++ b/src/lib/__tests__/catalog.test.ts
@@ -1,0 +1,86 @@
+import { describe, test, expect } from 'bun:test';
+
+import type { CatalogData } from '../catalog';
+
+import { findCatalogEntry } from '../catalog';
+
+describe('findCatalogEntry', () => {
+  test('finds package in default catalog field', () => {
+    const data: CatalogData = {
+      catalog: {
+        '@clerk/shared': '^1.0.0',
+        '@clerk/types': '^2.0.0',
+      },
+    };
+
+    const result = findCatalogEntry(data, '@clerk/shared');
+    expect(result).toEqual({ catalogName: 'default', version: '^1.0.0' });
+  });
+
+  test('finds package in a named catalogs entry', () => {
+    const data: CatalogData = {
+      catalogs: {
+        react: {
+          react: '^18.0.0',
+          'react-dom': '^18.0.0',
+        },
+        clerk: {
+          '@clerk/shared': '^1.0.0',
+        },
+      },
+    };
+
+    const result = findCatalogEntry(data, '@clerk/shared');
+    expect(result).toEqual({ catalogName: 'clerk', version: '^1.0.0' });
+  });
+
+  test('prefers default catalog over named catalogs', () => {
+    const data: CatalogData = {
+      catalog: {
+        '@clerk/shared': '^1.0.0',
+      },
+      catalogs: {
+        clerk: {
+          '@clerk/shared': '^2.0.0',
+        },
+      },
+    };
+
+    const result = findCatalogEntry(data, '@clerk/shared');
+    expect(result).toEqual({ catalogName: 'default', version: '^1.0.0' });
+  });
+
+  test('returns null when package is not in any catalog', () => {
+    const data: CatalogData = {
+      catalog: {
+        react: '^18.0.0',
+      },
+      catalogs: {
+        clerk: {
+          '@clerk/types': '^1.0.0',
+        },
+      },
+    };
+
+    const result = findCatalogEntry(data, '@clerk/shared');
+    expect(result).toBeNull();
+  });
+
+  test('returns null when data has no catalog fields', () => {
+    const data: CatalogData = {};
+
+    const result = findCatalogEntry(data, '@clerk/shared');
+    expect(result).toBeNull();
+  });
+
+  test('returns null when catalogs object has empty entries', () => {
+    const data: CatalogData = {
+      catalogs: {
+        empty: {},
+      },
+    };
+
+    const result = findCatalogEntry(data, '@clerk/shared');
+    expect(result).toBeNull();
+  });
+});

--- a/src/lib/__tests__/consumer.test.ts
+++ b/src/lib/__tests__/consumer.test.ts
@@ -1,8 +1,6 @@
 import { describe, test, expect } from 'bun:test';
 
-import type { CatalogData } from '../consumer';
-
-import { removepkglabBlock, findCatalogEntry, MARKER_START } from '../consumer';
+import { removepkglabBlock, MARKER_START } from '../consumer';
 
 const MARKER_END = '# pkglab-end';
 
@@ -68,86 +66,5 @@ describe('removepkglabBlock', () => {
     const result = removepkglabBlock(content);
     // After removing the block, only whitespace remains, trimmed to empty + \n
     expect(result).toBe('\n');
-  });
-});
-
-describe('findCatalogEntry', () => {
-  test('finds package in default catalog field', () => {
-    const data: CatalogData = {
-      catalog: {
-        '@clerk/shared': '^1.0.0',
-        '@clerk/types': '^2.0.0',
-      },
-    };
-
-    const result = findCatalogEntry(data, '@clerk/shared');
-    expect(result).toEqual({ catalogName: 'default', version: '^1.0.0' });
-  });
-
-  test('finds package in a named catalogs entry', () => {
-    const data: CatalogData = {
-      catalogs: {
-        react: {
-          react: '^18.0.0',
-          'react-dom': '^18.0.0',
-        },
-        clerk: {
-          '@clerk/shared': '^1.0.0',
-        },
-      },
-    };
-
-    const result = findCatalogEntry(data, '@clerk/shared');
-    expect(result).toEqual({ catalogName: 'clerk', version: '^1.0.0' });
-  });
-
-  test('prefers default catalog over named catalogs', () => {
-    const data: CatalogData = {
-      catalog: {
-        '@clerk/shared': '^1.0.0',
-      },
-      catalogs: {
-        clerk: {
-          '@clerk/shared': '^2.0.0',
-        },
-      },
-    };
-
-    const result = findCatalogEntry(data, '@clerk/shared');
-    expect(result).toEqual({ catalogName: 'default', version: '^1.0.0' });
-  });
-
-  test('returns null when package is not in any catalog', () => {
-    const data: CatalogData = {
-      catalog: {
-        react: '^18.0.0',
-      },
-      catalogs: {
-        clerk: {
-          '@clerk/types': '^1.0.0',
-        },
-      },
-    };
-
-    const result = findCatalogEntry(data, '@clerk/shared');
-    expect(result).toBeNull();
-  });
-
-  test('returns null when data has no catalog fields', () => {
-    const data: CatalogData = {};
-
-    const result = findCatalogEntry(data, '@clerk/shared');
-    expect(result).toBeNull();
-  });
-
-  test('returns null when catalogs object has empty entries', () => {
-    const data: CatalogData = {
-      catalogs: {
-        empty: {},
-      },
-    };
-
-    const result = findCatalogEntry(data, '@clerk/shared');
-    expect(result).toBeNull();
   });
 });

--- a/src/lib/catalog.ts
+++ b/src/lib/catalog.ts
@@ -1,0 +1,214 @@
+import { join } from 'node:path';
+
+import { atomicWrite } from './fs';
+
+export type CatalogFormat = 'package-json' | 'pnpm-workspace';
+
+export interface CatalogData {
+  catalog?: Record<string, string>;
+  catalogs?: Record<string, Record<string, string>>;
+  [key: string]: unknown;
+}
+
+/**
+ * Walk up from startDir to find the nearest catalog definition.
+ * Checks pnpm-workspace.yaml first, then package.json.
+ */
+export async function findCatalogRoot(startDir: string): Promise<{ root: string; format: CatalogFormat } | null> {
+  let dir = startDir;
+  while (true) {
+    // Check pnpm-workspace.yaml first
+    const wsFile = Bun.file(join(dir, 'pnpm-workspace.yaml'));
+    if (await wsFile.exists()) {
+      const { parse } = await import('yaml');
+      const content = parse(await wsFile.text());
+      if (content?.catalog || content?.catalogs) {
+        return { root: dir, format: 'pnpm-workspace' };
+      }
+    }
+
+    // Check package.json catalogs (bun/npm)
+    const file = Bun.file(join(dir, 'package.json'));
+    if (await file.exists()) {
+      const pkgJson = await file.json();
+      if (pkgJson.catalog || pkgJson.catalogs) {
+        return { root: dir, format: 'package-json' };
+      }
+    }
+
+    const parent = join(dir, '..');
+    if (parent === dir) {
+      return null;
+    }
+    dir = parent;
+  }
+}
+
+/**
+ * Load catalog data from either package.json or pnpm-workspace.yaml.
+ */
+export async function loadCatalogData(rootDir: string, format: CatalogFormat): Promise<CatalogData> {
+  if (format === 'pnpm-workspace') {
+    const { parse } = await import('yaml');
+    const text = await Bun.file(join(rootDir, 'pnpm-workspace.yaml')).text();
+    return parse(text) as CatalogData;
+  }
+  return Bun.file(join(rootDir, 'package.json')).json() as Promise<CatalogData>;
+}
+
+/**
+ * Load named catalogs from pnpm-workspace.yaml.
+ * Returns an empty object if the file doesn't exist or has no catalogs.
+ */
+export async function loadCatalogs(workspaceRoot: string): Promise<Record<string, Record<string, string>>> {
+  const file = Bun.file(join(workspaceRoot, 'pnpm-workspace.yaml'));
+  if (!(await file.exists())) {
+    return {};
+  }
+
+  const { parse } = await import('yaml');
+  const content = parse(await file.text());
+  if (!content?.catalogs || typeof content.catalogs !== 'object') {
+    return {};
+  }
+
+  const result: Record<string, Record<string, string>> = {};
+  for (const [name, entries] of Object.entries(content.catalogs)) {
+    if (entries && typeof entries === 'object') {
+      result[name] = entries as Record<string, string>;
+    }
+  }
+  return result;
+}
+
+/**
+ * Find which catalog (default or named) contains a given package.
+ * Works for both package.json and pnpm-workspace.yaml data since they
+ * share the same catalog/catalogs structure.
+ * Returns null if the package isn't in any catalog.
+ */
+export function findCatalogEntry(data: CatalogData, pkgName: string): { catalogName: string; version: string } | null {
+  if (data?.catalog?.[pkgName] !== undefined) {
+    return { catalogName: 'default', version: data.catalog[pkgName] };
+  }
+  if (data?.catalogs) {
+    for (const [name, entries] of Object.entries(data.catalogs)) {
+      if (entries && typeof entries === 'object' && entries[pkgName] !== undefined) {
+        return { catalogName: name, version: entries[pkgName] };
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Update a version in the workspace root catalog (or named catalog).
+ * Dispatches to the right file format based on the format parameter.
+ */
+export async function updateCatalogVersion(
+  rootDir: string,
+  pkgName: string,
+  version: string,
+  catalogName: string,
+  format: CatalogFormat = 'package-json',
+): Promise<{ previousVersion: string | null }> {
+  if (format === 'pnpm-workspace') {
+    return updatePnpmCatalogVersion(rootDir, pkgName, version, catalogName);
+  }
+  return updatePackageJsonCatalogVersion(rootDir, pkgName, version, catalogName);
+}
+
+async function updatePackageJsonCatalogVersion(
+  rootDir: string,
+  pkgName: string,
+  version: string,
+  catalogName: string,
+): Promise<{ previousVersion: string | null }> {
+  const pkgJsonPath = join(rootDir, 'package.json');
+  const pkgJson = await Bun.file(pkgJsonPath).json();
+
+  let previousVersion: string | null = null;
+  if (catalogName === 'default') {
+    if (pkgJson.catalog?.[pkgName] !== undefined) {
+      previousVersion = pkgJson.catalog[pkgName];
+      pkgJson.catalog[pkgName] = version;
+    }
+  } else {
+    if (pkgJson.catalogs?.[catalogName]?.[pkgName] !== undefined) {
+      previousVersion = pkgJson.catalogs[catalogName][pkgName];
+      pkgJson.catalogs[catalogName][pkgName] = version;
+    }
+  }
+
+  await atomicWrite(pkgJsonPath, JSON.stringify(pkgJson, null, 2) + '\n');
+  return { previousVersion };
+}
+
+async function updatePnpmCatalogVersion(
+  rootDir: string,
+  pkgName: string,
+  version: string,
+  catalogName: string,
+): Promise<{ previousVersion: string | null }> {
+  const { parse, stringify } = await import('yaml');
+  const wsPath = join(rootDir, 'pnpm-workspace.yaml');
+  const text = await Bun.file(wsPath).text();
+  const ws = parse(text);
+
+  let previousVersion: string | null = null;
+  if (catalogName === 'default') {
+    if (ws.catalog?.[pkgName] !== undefined) {
+      previousVersion = ws.catalog[pkgName];
+      ws.catalog[pkgName] = version;
+    }
+  } else {
+    if (ws.catalogs?.[catalogName]?.[pkgName] !== undefined) {
+      previousVersion = ws.catalogs[catalogName][pkgName];
+      ws.catalogs[catalogName][pkgName] = version;
+    }
+  }
+
+  await atomicWrite(wsPath, stringify(ws));
+  return { previousVersion };
+}
+
+/**
+ * Remove a package entry from a catalog. Used when restoring or rolling back
+ * a package that was freshly added by pkglab (no original version to restore).
+ */
+export async function removeCatalogEntry(
+  rootDir: string,
+  pkgName: string,
+  catalogName: string,
+  format: CatalogFormat = 'package-json',
+): Promise<void> {
+  if (format === 'pnpm-workspace') {
+    const { parse, stringify } = await import('yaml');
+    const wsPath = join(rootDir, 'pnpm-workspace.yaml');
+    const text = await Bun.file(wsPath).text();
+    const ws = parse(text);
+    if (catalogName === 'default') {
+      if (ws.catalog) {
+        delete ws.catalog[pkgName];
+      }
+    } else {
+      if (ws.catalogs?.[catalogName]) {
+        delete ws.catalogs[catalogName][pkgName];
+      }
+    }
+    await atomicWrite(wsPath, stringify(ws));
+  } else {
+    const pkgJsonPath = join(rootDir, 'package.json');
+    const pkgJson = await Bun.file(pkgJsonPath).json();
+    if (catalogName === 'default') {
+      if (pkgJson.catalog) {
+        delete pkgJson.catalog[pkgName];
+      }
+    } else {
+      if (pkgJson.catalogs?.[catalogName]) {
+        delete pkgJson.catalogs[catalogName][pkgName];
+      }
+    }
+    await atomicWrite(pkgJsonPath, JSON.stringify(pkgJson, null, 2) + '\n');
+  }
+}

--- a/src/lib/consumer.ts
+++ b/src/lib/consumer.ts
@@ -1,18 +1,17 @@
 import { join } from 'node:path';
 
-import type { PublishPlan, PublishEntry, RepoEntry, RepoState } from '../types';
 import type { PendingUpdate } from '../types';
 import type { PackageManager } from './pm-detect';
 
+import { type CatalogFormat, findCatalogRoot, updateCatalogVersion, removeCatalogEntry } from './catalog';
 import { NpmrcConflictError } from './errors';
 import { atomicWrite } from './fs';
 import { patchPnpmLockfile } from './lockfile-patch';
 import { log } from './log';
-import { detectPackageManager } from './pm-detect';
 import { pmCommand, run } from './proc';
 import { getActiveRepos } from './repo-state';
 
-export type { LockfilePatchEntry } from './lockfile-patch';
+export type { CatalogFormat } from './catalog';
 
 export const MARKER_START = '# pkglab-start';
 const MARKER_END = '# pkglab-end';
@@ -293,8 +292,6 @@ export async function restorePackage(
   }
 }
 
-export type CatalogFormat = 'package-json' | 'pnpm-workspace';
-
 export interface VersionEntry {
   name: string;
   version: string;
@@ -466,190 +463,6 @@ export async function installWithVersionUpdates(
   return previousVersions;
 }
 
-/**
- * Walk up from startDir to find the nearest catalog definition.
- * Checks pnpm-workspace.yaml first, then package.json.
- */
-export async function findCatalogRoot(startDir: string): Promise<{ root: string; format: CatalogFormat } | null> {
-  let dir = startDir;
-  while (true) {
-    // Check pnpm-workspace.yaml first
-    const wsFile = Bun.file(join(dir, 'pnpm-workspace.yaml'));
-    if (await wsFile.exists()) {
-      const { parse } = await import('yaml');
-      const content = parse(await wsFile.text());
-      if (content?.catalog || content?.catalogs) {
-        return { root: dir, format: 'pnpm-workspace' };
-      }
-    }
-
-    // Check package.json catalogs (bun/npm)
-    const file = Bun.file(join(dir, 'package.json'));
-    if (await file.exists()) {
-      const pkgJson = await file.json();
-      if (pkgJson.catalog || pkgJson.catalogs) {
-        return { root: dir, format: 'package-json' };
-      }
-    }
-
-    const parent = join(dir, '..');
-    if (parent === dir) {
-      return null;
-    }
-    dir = parent;
-  }
-}
-
-export interface CatalogData {
-  catalog?: Record<string, string>;
-  catalogs?: Record<string, Record<string, string>>;
-  [key: string]: unknown;
-}
-
-/**
- * Load catalog data from either package.json or pnpm-workspace.yaml.
- */
-export async function loadCatalogData(rootDir: string, format: CatalogFormat): Promise<CatalogData> {
-  if (format === 'pnpm-workspace') {
-    const { parse } = await import('yaml');
-    const text = await Bun.file(join(rootDir, 'pnpm-workspace.yaml')).text();
-    return parse(text) as CatalogData;
-  }
-  return Bun.file(join(rootDir, 'package.json')).json() as Promise<CatalogData>;
-}
-
-/**
- * Find which catalog (default or named) contains a given package.
- * Works for both package.json and pnpm-workspace.yaml data since they
- * share the same catalog/catalogs structure.
- * Returns null if the package isn't in any catalog.
- */
-export function findCatalogEntry(data: CatalogData, pkgName: string): { catalogName: string; version: string } | null {
-  if (data?.catalog?.[pkgName] !== undefined) {
-    return { catalogName: 'default', version: data.catalog[pkgName] };
-  }
-  if (data?.catalogs) {
-    for (const [name, entries] of Object.entries(data.catalogs)) {
-      if (entries && typeof entries === 'object' && entries[pkgName] !== undefined) {
-        return { catalogName: name, version: entries[pkgName] };
-      }
-    }
-  }
-  return null;
-}
-
-/**
- * Update a version in the workspace root catalog (or named catalog).
- * Dispatches to the right file format based on the format parameter.
- */
-export async function updateCatalogVersion(
-  rootDir: string,
-  pkgName: string,
-  version: string,
-  catalogName: string,
-  format: CatalogFormat = 'package-json',
-): Promise<{ previousVersion: string | null }> {
-  if (format === 'pnpm-workspace') {
-    return updatePnpmCatalogVersion(rootDir, pkgName, version, catalogName);
-  }
-  return updatePackageJsonCatalogVersion(rootDir, pkgName, version, catalogName);
-}
-
-async function updatePackageJsonCatalogVersion(
-  rootDir: string,
-  pkgName: string,
-  version: string,
-  catalogName: string,
-): Promise<{ previousVersion: string | null }> {
-  const pkgJsonPath = join(rootDir, 'package.json');
-  const pkgJson = await Bun.file(pkgJsonPath).json();
-
-  let previousVersion: string | null = null;
-  if (catalogName === 'default') {
-    if (pkgJson.catalog?.[pkgName] !== undefined) {
-      previousVersion = pkgJson.catalog[pkgName];
-      pkgJson.catalog[pkgName] = version;
-    }
-  } else {
-    if (pkgJson.catalogs?.[catalogName]?.[pkgName] !== undefined) {
-      previousVersion = pkgJson.catalogs[catalogName][pkgName];
-      pkgJson.catalogs[catalogName][pkgName] = version;
-    }
-  }
-
-  await atomicWrite(pkgJsonPath, JSON.stringify(pkgJson, null, 2) + '\n');
-  return { previousVersion };
-}
-
-async function updatePnpmCatalogVersion(
-  rootDir: string,
-  pkgName: string,
-  version: string,
-  catalogName: string,
-): Promise<{ previousVersion: string | null }> {
-  const { parse, stringify } = await import('yaml');
-  const wsPath = join(rootDir, 'pnpm-workspace.yaml');
-  const text = await Bun.file(wsPath).text();
-  const ws = parse(text);
-
-  let previousVersion: string | null = null;
-  if (catalogName === 'default') {
-    if (ws.catalog?.[pkgName] !== undefined) {
-      previousVersion = ws.catalog[pkgName];
-      ws.catalog[pkgName] = version;
-    }
-  } else {
-    if (ws.catalogs?.[catalogName]?.[pkgName] !== undefined) {
-      previousVersion = ws.catalogs[catalogName][pkgName];
-      ws.catalogs[catalogName][pkgName] = version;
-    }
-  }
-
-  await atomicWrite(wsPath, stringify(ws));
-  return { previousVersion };
-}
-
-/**
- * Remove a package entry from a catalog. Used when restoring or rolling back
- * a package that was freshly added by pkglab (no original version to restore).
- */
-export async function removeCatalogEntry(
-  rootDir: string,
-  pkgName: string,
-  catalogName: string,
-  format: CatalogFormat = 'package-json',
-): Promise<void> {
-  if (format === 'pnpm-workspace') {
-    const { parse, stringify } = await import('yaml');
-    const wsPath = join(rootDir, 'pnpm-workspace.yaml');
-    const text = await Bun.file(wsPath).text();
-    const ws = parse(text);
-    if (catalogName === 'default') {
-      if (ws.catalog) {
-        delete ws.catalog[pkgName];
-      }
-    } else {
-      if (ws.catalogs?.[catalogName]) {
-        delete ws.catalogs[catalogName][pkgName];
-      }
-    }
-    await atomicWrite(wsPath, stringify(ws));
-  } else {
-    const pkgJsonPath = join(rootDir, 'package.json');
-    const pkgJson = await Bun.file(pkgJsonPath).json();
-    if (catalogName === 'default') {
-      if (pkgJson.catalog) {
-        delete pkgJson.catalog[pkgName];
-      }
-    } else {
-      if (pkgJson.catalogs?.[catalogName]) {
-        delete pkgJson.catalogs[catalogName][pkgName];
-      }
-    }
-    await atomicWrite(pkgJsonPath, JSON.stringify(pkgJson, null, 2) + '\n');
-  }
-}
-
 export async function ensureNpmrcForActiveRepos(port: number): Promise<void> {
   const activeRepos = await getActiveRepos();
   for (const { displayName, state } of activeRepos) {
@@ -693,62 +506,6 @@ async function disableBunManifestCache(dir: string): Promise<() => Promise<void>
       await Bun.write(path, original);
     }
   };
-}
-
-export interface RepoWorkItem {
-  displayName: string;
-  state: RepoState;
-  pm: PackageManager;
-  packages: PublishEntry[];
-}
-
-/**
- * Build per-repo work items: which packages to update and the package manager to use.
- * Filters to repos that have at least one package from the plan matching by tag.
- */
-export async function buildConsumerWorkItems(
-  plan: PublishPlan,
-  tag?: string,
-  preloadedRepos?: RepoEntry[],
-): Promise<RepoWorkItem[]> {
-  const activeRepos = await getActiveRepos(preloadedRepos);
-  if (activeRepos.length === 0) {
-    return [];
-  }
-
-  const pubTag = tag ?? null;
-  const repoWork = await Promise.all(
-    activeRepos.map(async ({ displayName, state }) => {
-      const pm = await detectPackageManager(state.path);
-      const packages = plan.packages.filter(e => {
-        const link = state.packages[e.name];
-        if (!link) {
-          return false;
-        }
-        const linkTag = link.tag ?? null;
-        return linkTag === pubTag;
-      });
-      return { displayName, state, pm, packages };
-    }),
-  );
-  return repoWork.filter(r => r.packages.length > 0);
-}
-
-export async function buildVersionEntries(
-  repo: RepoWorkItem,
-): Promise<{ entries: VersionEntry[]; catalogRoot: string | undefined }> {
-  const entries: VersionEntry[] = repo.packages.map(e => {
-    const link = repo.state.packages[e.name];
-    return {
-      name: e.name,
-      version: e.version,
-      catalogName: link?.catalogName,
-      catalogFormat: link?.catalogFormat,
-      targets: link?.targets.map(t => ({ dir: t.dir })) ?? [{ dir: '.' }],
-    };
-  });
-  const catalogResult = entries.some(e => e.catalogName) ? await findCatalogRoot(repo.state.path) : null;
-  return { entries, catalogRoot: catalogResult?.root };
 }
 
 /**

--- a/src/lib/consumer.ts
+++ b/src/lib/consumer.ts
@@ -1,17 +1,15 @@
 import { join } from 'node:path';
 
-import type { PendingUpdate } from '../types';
+import type { PendingUpdate, VersionEntry } from '../types';
 import type { PackageManager } from './pm-detect';
 
-import { type CatalogFormat, findCatalogRoot, updateCatalogVersion, removeCatalogEntry } from './catalog';
+import { findCatalogRoot, updateCatalogVersion, removeCatalogEntry } from './catalog';
 import { NpmrcConflictError } from './errors';
 import { atomicWrite } from './fs';
 import { patchPnpmLockfile } from './lockfile-patch';
 import { log } from './log';
 import { pmCommand, run } from './proc';
 import { getActiveRepos } from './repo-state';
-
-export type { CatalogFormat } from './catalog';
 
 export const MARKER_START = '# pkglab-start';
 const MARKER_END = '# pkglab-end';
@@ -290,14 +288,6 @@ export async function restorePackage(
   } else {
     log.info(`Removed ${pkgName} (was added by pkglab, no original version)`);
   }
-}
-
-export interface VersionEntry {
-  name: string;
-  version: string;
-  catalogName?: string;
-  catalogFormat?: CatalogFormat;
-  targets: Array<{ dir: string }>;
 }
 
 interface InstallWithVersionUpdatesOpts {

--- a/src/lib/install-orchestrator.ts
+++ b/src/lib/install-orchestrator.ts
@@ -1,7 +1,6 @@
-import type { PublishPlan, PublishEntry, RepoEntry, RepoState } from '../types';
+import type { PublishPlan, PublishEntry, RepoEntry, RepoState, VersionEntry } from '../types';
 import type { LockfilePatchEntry } from './lockfile-patch';
 import type { PackageManager } from './pm-detect';
-import type { VersionEntry } from './consumer';
 
 import { findCatalogRoot } from './catalog';
 import { installWithVersionUpdates } from './consumer';

--- a/src/lib/install-orchestrator.ts
+++ b/src/lib/install-orchestrator.ts
@@ -1,0 +1,195 @@
+import type { PublishPlan, PublishEntry, RepoEntry, RepoState } from '../types';
+import type { LockfilePatchEntry } from './lockfile-patch';
+import type { PackageManager } from './pm-detect';
+import type { VersionEntry } from './consumer';
+
+import { findCatalogRoot } from './catalog';
+import { installWithVersionUpdates } from './consumer';
+import { runPreHook, runPostHook, runErrorHook } from './hooks';
+import { log } from './log';
+import { detectPackageManager } from './pm-detect';
+import { getActiveRepos, saveRepoByPath } from './repo-state';
+
+export interface RepoWorkItem {
+  displayName: string;
+  state: RepoState;
+  pm: PackageManager;
+  packages: PublishEntry[];
+}
+
+/**
+ * Build per-repo work items: which packages to update and the package manager to use.
+ * Filters to repos that have at least one package from the plan matching by tag.
+ */
+export async function buildConsumerWorkItems(
+  plan: PublishPlan,
+  tag?: string,
+  preloadedRepos?: RepoEntry[],
+): Promise<RepoWorkItem[]> {
+  const activeRepos = await getActiveRepos(preloadedRepos);
+  if (activeRepos.length === 0) {
+    return [];
+  }
+
+  const pubTag = tag ?? null;
+  const repoWork = await Promise.all(
+    activeRepos.map(async ({ displayName, state }) => {
+      const pm = await detectPackageManager(state.path);
+      const packages = plan.packages.filter(e => {
+        const link = state.packages[e.name];
+        if (!link) {
+          return false;
+        }
+        const linkTag = link.tag ?? null;
+        return linkTag === pubTag;
+      });
+      return { displayName, state, pm, packages };
+    }),
+  );
+  return repoWork.filter(r => r.packages.length > 0);
+}
+
+export async function buildVersionEntries(
+  repo: RepoWorkItem,
+): Promise<{ entries: VersionEntry[]; catalogRoot: string | undefined }> {
+  const entries: VersionEntry[] = repo.packages.map(e => {
+    const link = repo.state.packages[e.name];
+    return {
+      name: e.name,
+      version: e.version,
+      catalogName: link?.catalogName,
+      catalogFormat: link?.catalogFormat,
+      targets: link?.targets.map(t => ({ dir: t.dir })) ?? [{ dir: '.' }],
+    };
+  });
+  const catalogResult = entries.some(e => e.catalogName) ? await findCatalogRoot(repo.state.path) : null;
+  return { entries, catalogRoot: catalogResult?.root };
+}
+
+export async function runRepoInstall(
+  repo: RepoWorkItem,
+  hookOpts?: { tag: string | undefined; port: number; verbose: boolean },
+  getIntegrityMap?: () => Promise<Map<string, string>>,
+  noPmOptimizations = false,
+  onLockfilePatched?: (entryCount: number) => void,
+): Promise<'ok' | 'skipped'> {
+  const { entries, catalogRoot } = await buildVersionEntries(repo);
+
+  // Build hook context if hook opts provided
+  const hookCtx = hookOpts
+    ? {
+        event: 'update' as const,
+        packages: repo.packages.map(e => ({
+          name: e.name,
+          version: e.version,
+          previous: repo.state.packages[e.name]?.current,
+        })),
+        tag: hookOpts.tag ?? null,
+        repoPath: repo.state.path,
+        registryUrl: `http://127.0.0.1:${hookOpts.port}`,
+        packageManager: repo.pm,
+      }
+    : null;
+
+  // Pre-update hook
+  if (hookCtx) {
+    const preResult = await runPreHook(hookCtx);
+    if (preResult.status === 'ok') {
+      log.success(`  pre-update (${(preResult.durationMs / 1000).toFixed(1)}s)`);
+    } else if (preResult.status === 'aborted' || preResult.status === 'failed' || preResult.status === 'timed_out') {
+      const label = preResult.status === 'timed_out' ? 'timed out' : `aborted (exit ${preResult.exitCode ?? 1})`;
+      log.warn(`  pre-update ${label} - skipped`);
+      await runErrorHook({
+        ...hookCtx,
+        error: { stage: 'pre-hook', message: `pre-update hook ${label}`, failedHook: 'pre-update' },
+      });
+      return 'skipped';
+    }
+  }
+
+  // Build lockfile patch entries for pnpm repos.
+  // Include ALL published packages (not just tracked ones) because the lockfile
+  // may contain transitive pkglab dependencies that also need integrity updates.
+  let patchEntries: LockfilePatchEntry[] | undefined;
+  if (repo.pm === 'pnpm' && getIntegrityMap) {
+    const integrityMap = await getIntegrityMap();
+    if (integrityMap.size > 0) {
+      // Pre-compute fallback for transitive deps not directly tracked
+      const fallbackOldVersion = Object.values(repo.state.packages).find(p => p.current)?.current;
+      patchEntries = [];
+      for (const [name, integrity] of integrityMap) {
+        const oldVersion = repo.state.packages[name]?.current ?? fallbackOldVersion;
+        const newVersion = repo.packages.find(p => p.name === name)?.version ?? repo.packages[0].version;
+        if (oldVersion) {
+          patchEntries.push({ name, oldVersion, newVersion, integrity });
+        }
+      }
+    }
+  }
+
+  // Install and save state.
+  // Save pending state before install so crash recovery can detect dirty consumers.
+  try {
+    // Mark pending update before modifying consumer files.
+    // Capture current versions so crash recovery can roll back.
+    repo.state.pendingUpdate = {
+      packages: Object.fromEntries(
+        entries.map(e => {
+          const link = repo.state.packages[e.name];
+          return [
+            e.name,
+            e.targets.map(t => {
+              const existingTarget = link?.targets.find(lt => lt.dir === t.dir);
+              return { dir: t.dir, original: existingTarget?.original ?? link?.current ?? '' };
+            }),
+          ];
+        }),
+      ),
+      timestamp: Date.now(),
+    };
+    await saveRepoByPath(repo.state.path, repo.state);
+
+    await installWithVersionUpdates({
+      repoPath: repo.state.path,
+      catalogRoot,
+      entries,
+      pm: repo.pm,
+      registryUrl: hookOpts ? `http://127.0.0.1:${hookOpts.port}` : undefined,
+      patchEntries,
+      noPmOptimizations,
+      onLockfilePatched,
+    });
+
+    for (const entry of repo.packages) {
+      const link = repo.state.packages[entry.name];
+      if (link) {
+        link.current = entry.version;
+      }
+    }
+    // Clear pending state on success
+    delete repo.state.pendingUpdate;
+    await saveRepoByPath(repo.state.path, repo.state);
+  } catch (err) {
+    if (hookCtx) {
+      const message = err instanceof Error ? err.message : String(err);
+      await runErrorHook({
+        ...hookCtx,
+        error: { stage: 'operation', message, failedHook: null },
+      });
+    }
+    throw err;
+  }
+
+  // Post-update hook
+  if (hookCtx) {
+    const postResult = await runPostHook(hookCtx);
+    if (postResult.status === 'ok') {
+      log.success(`  post-update (${(postResult.durationMs / 1000).toFixed(1)}s)`);
+    } else if (postResult.status === 'failed' || postResult.status === 'timed_out') {
+      const label = postResult.status === 'timed_out' ? 'timed out' : `failed (exit ${postResult.exitCode ?? 1})`;
+      log.warn(`  post-update hook ${label}`);
+    }
+  }
+
+  return 'ok';
+}

--- a/src/lib/workspace.ts
+++ b/src/lib/workspace.ts
@@ -33,27 +33,6 @@ export function findPackage(packages: WorkspacePackage[], name: string): Workspa
   return packages.find(p => p.name === name);
 }
 
-export async function loadCatalogs(workspaceRoot: string): Promise<Record<string, Record<string, string>>> {
-  const file = Bun.file(join(workspaceRoot, 'pnpm-workspace.yaml'));
-  if (!(await file.exists())) {
-    return {};
-  }
-
-  const { parse } = await import('yaml');
-  const content = parse(await file.text());
-  if (!content?.catalogs || typeof content.catalogs !== 'object') {
-    return {};
-  }
-
-  const result: Record<string, Record<string, string>> = {};
-  for (const [name, entries] of Object.entries(content.catalogs)) {
-    if (entries && typeof entries === 'object') {
-      result[name] = entries as Record<string, string>;
-    }
-  }
-  return result;
-}
-
 /**
  * Discover workspace and collect root + sub-package package.json data.
  * Returns undefined if the path is not a workspace.

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,6 +76,14 @@ export interface RepoEntry {
   state: RepoState;
 }
 
+export interface VersionEntry {
+  name: string;
+  version: string;
+  catalogName?: string;
+  catalogFormat?: 'package-json' | 'pnpm-workspace';
+  targets: Array<{ dir: string }>;
+}
+
 export interface DaemonInfo {
   pid: number;
   port: number;


### PR DESCRIPTION
## Summary

Addresses #2 — splits `pub.ts` and `add.ts` into composable modules by extracting shared logic into focused library files.

- **`src/lib/catalog.ts`** (new, 214 lines): All catalog detection, loading, querying, updating, and removal — extracted from `consumer.ts` (and `loadCatalogs` from `workspace.ts`)
- **`src/lib/install-orchestrator.ts`** (new, 195 lines): `RepoWorkItem`, `buildConsumerWorkItems`, `buildVersionEntries`, and `runRepoInstall` — extracted from `consumer.ts` and `pub.ts`
- **`consumer.ts`**: 801 → 557 lines (focused on npmrc, hooks, package.json mutation, install, restore)
- **`pub.ts`**: 789 → 656 lines (removed inline `runRepoInstall`, now imports from orchestrator)

No behavioral changes — purely structural. `cascade.ts` was already extracted in a prior PR, completing 3/3 proposed extractions from the issue.

## Test plan

- [x] `tsc --noEmit` passes (no type errors)
- [x] 185 unit tests pass
- [x] 163 e2e tests pass
- [ ] Manual smoke test: `pkglab pub` and `pkglab add` work end-to-end