### PR TITLE
Discord (support → community), X, and support email updates

### DIFF
--- a/.changeset/fine-tools-stop.md
+++ b/.changeset/fine-tools-stop.md
@@ -1,5 +1,5 @@
 ---
-"pkglab": patch
+'pkglab': patch
 ---
 
 Update contact links

--- a/.changeset/fine-tools-stop.md
+++ b/.changeset/fine-tools-stop.md
@@ -1,0 +1,5 @@
+---
+"pkglab": patch
+---
+
+Update contact links

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,6 @@
 - 02f69d6: Cross-platform PID validation with Linux /proc fallback, exclusive lock for listener startup, user-specific log directory
 - f5303e3: Harden daemon startup race, stop verification, stderr drain, and PID validation
 - aa3cade: Fix correctness, crash safety, and race condition bugs across commands and core libraries
-
   - Fix re-add overwriting original version in repo state (add.ts)
   - Scan peerDependencies and optionalDependencies during version updates (consumer.ts)
   - Fix npmrc marker removal when markers are out of order (consumer.ts)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
     <img alt="Discord" src="https://img.shields.io/discord/856971667393609759?color=7389D8&label&logo=discord&logoColor=ffffff" />
   </a>
   <a href="https://x.com/clerk">
-    <img alt="Twitter" src="https://img.shields.io/twitter/url.svg?label=%40clerk&style=social&url=https%3A%2F%2Fx.com%2Fclerk" />
+    <img alt="Follow on X" src="https://img.shields.io/twitter/url.svg?label=%40clerk&style=social&url=https%3A%2F%2Fx.com%2Fclerk" />
   </a>
   <br />
   <br />

--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@
   <a href="https://clerk.com/discord">
     <img alt="Discord" src="https://img.shields.io/discord/856971667393609759?color=7389D8&label&logo=discord&logoColor=ffffff" />
   </a>
-  <a href="https://twitter.com/clerkdev">
-    <img alt="Twitter" src="https://img.shields.io/twitter/url.svg?label=%40clerkdev&style=social&url=https%3A%2F%2Ftwitter.com%2Fclerkdev" />
+  <a href="https://x.com/clerk">
+    <img alt="Twitter" src="https://img.shields.io/twitter/url.svg?label=%40clerk&style=social&url=https%3A%2F%2Fx.com%2Fclerk" />
   </a>
   <br />
   <br />


### PR DESCRIPTION
## Summary

## Why

Clerk Discord support officially ends **2026-06-15**. After that date, Discord is a community space only — all support will then route through `clerk.com/contact/support` or `support@clerk.com`.

This PR aligns this repo's copy and links with that change. While in the same files, it also fixes adjacent updates for our X.com handle and support email.

## Changes (if needed)

1. **Discord framing** → community framing only. Never described as "support thread", "support channel", or as a place to "get help".
2. **Discord URL** → Use `https://clerk.com/discord` instead of direct invitation URL.
3. **Help/support links** → `https://clerk.com/contact/support` or `support@clerk.com`. Also updating `support@clerk.dev` → `support@clerk.com`.
4. **Twitter/X URLs** → Changes `twitter.com` → `x.com` and `@ClerkDev` → `@clerk` on Clerk-owned URLs only. Third-party author handles, OAuth-protocol examples, and quoted-tweet permalinks intentionally untouched.

## Companion PRs

- **AutoMap**: https://github.com/clerk/AutoMap/pull/49
- **api-keys-shadcn-demo**: https://github.com/clerk/api-keys-shadcn-demo/pull/2
- **cached-pricing-table**: https://github.com/clerk/cached-pricing-table/pull/3
- **clerk**: https://github.com/clerk/clerk/pull/2639
- **clerk-android**: https://github.com/clerk/clerk-android/pull/662
- **clerk-astro-quickstart**: https://github.com/clerk/clerk-astro-quickstart/pull/15
- **clerk-b2b-saas-starter**: https://github.com/clerk/clerk-b2b-saas-starter/pull/6
- **clerk-chrome-extension-demo**: https://github.com/clerk/clerk-chrome-extension-demo/pull/174
- **clerk-chrome-extension-quickstart**: https://github.com/clerk/clerk-chrome-extension-quickstart/pull/8
- **clerk-docs**: https://github.com/clerk/clerk-docs/pull/3392
- **clerk-expo-quickstart**: https://github.com/clerk/clerk-expo-quickstart/pull/45
- **clerk-express-quickstart**: https://github.com/clerk/clerk-express-quickstart/pull/6
- **clerk-fastify-quickstart**: https://github.com/clerk/clerk-fastify-quickstart/pull/10
- **clerk-ios**: https://github.com/clerk/clerk-ios/pull/419
- **clerk-javascript-quickstart**: https://github.com/clerk/clerk-javascript-quickstart/pull/4
- **clerk-multidomain-demo**: https://github.com/clerk/clerk-multidomain-demo/pull/197
- **clerk-nextjs-app-quickstart**: https://github.com/clerk/clerk-nextjs-app-quickstart/pull/39
- **clerk-nextjs-onboarding-sample-app**: https://github.com/clerk/clerk-nextjs-onboarding-sample-app/pull/15
- **clerk-nextjs-pages-quickstart**: https://github.com/clerk/clerk-nextjs-pages-quickstart/pull/15
- **clerk-nextjs-quickstart-demo-app**: https://github.com/clerk/clerk-nextjs-quickstart-demo-app/pull/5
- **clerk-nextjs-trpc-drizzle**: https://github.com/clerk/clerk-nextjs-trpc-drizzle/pull/5
- **clerk-nextjs-trpc-prisma**: https://github.com/clerk/clerk-nextjs-trpc-prisma/pull/6
- **clerk-nuxt-quickstart**: https://github.com/clerk/clerk-nuxt-quickstart/pull/12
- **clerk-react-quickstart**: https://github.com/clerk/clerk-react-quickstart/pull/13
- **clerk-react-router-quickstart**: https://github.com/clerk/clerk-react-router-quickstart/pull/10
- **clerk-sdk-flutter**: https://github.com/clerk/clerk-sdk-flutter/pull/413
- **clerk-sdk-go**: https://github.com/clerk/clerk-sdk-go/pull/561
- **clerk-sdk-php**: https://github.com/clerk/clerk-sdk-php/pull/76
- **clerk-sdk-python**: https://github.com/clerk/clerk-sdk-python/pull/232
- **clerk-supabase-nextjs**: https://github.com/clerk/clerk-supabase-nextjs/pull/8
- **clerk-tanstack-react-start-quickstart**: https://github.com/clerk/clerk-tanstack-react-start-quickstart/pull/11
- **clerk-vue-quickstart**: https://github.com/clerk/clerk-vue-quickstart/pull/6
- **dashboard**: https://github.com/clerk/dashboard/pull/9328
- **demo-api-keys**: https://github.com/clerk/demo-api-keys/pull/3
- **demos**: https://github.com/clerk/demos/pull/1
- **easie**: https://github.com/clerk/easie/pull/28
- **examples**: https://github.com/clerk/examples/pull/76
- **javascript**: https://github.com/clerk/javascript/pull/8650
- **launch-darker**: https://github.com/clerk/launch-darker/pull/6
- **lead-agent**: https://github.com/clerk/lead-agent/pull/24
- **mcp-tools**: https://github.com/clerk/mcp-tools/pull/29
- **nextjs-auth-starter-template**: https://github.com/clerk/nextjs-auth-starter-template/pull/56
- **skills**: https://github.com/clerk/skills/pull/47
- **support-tools**: https://github.com/clerk/support-tools/pull/1493
- **v0-b2b-saas-template-8j**: https://github.com/clerk/v0-b2b-saas-template-8j/pull/4
